### PR TITLE
Wifi segment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ Output/
 
 # images
 *.png
+
+local/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,26 @@
   "go.formatTool": "gofmt",
   "go.formatFlags": [
     "-s"
-  ]
+  ],
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#6dfea3",
+    "activityBar.activeBorder": "#af80fe",
+    "activityBar.background": "#6dfea3",
+    "activityBar.foreground": "#15202b",
+    "activityBar.inactiveForeground": "#15202b99",
+    "activityBarBadge.background": "#af80fe",
+    "activityBarBadge.foreground": "#15202b",
+    "sash.hoverBorder": "#6dfea3",
+    "statusBar.background": "#3bfd83",
+    "statusBar.foreground": "#15202b",
+    "statusBarItem.hoverBackground": "#08fc63",
+    "statusBarItem.remoteBackground": "#3bfd83",
+    "statusBarItem.remoteForeground": "#15202b",
+    "titleBar.activeBackground": "#3bfd83",
+    "titleBar.activeForeground": "#15202b",
+    "titleBar.inactiveBackground": "#3bfd8399",
+    "titleBar.inactiveForeground": "#15202b99"
+  },
+  "peacock.color": "#3bfd83",
+  "peacock.remoteColor": "#c0f2c7"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,5 +36,6 @@
     "titleBar.inactiveForeground": "#15202b99"
   },
   "peacock.color": "#3bfd83",
-  "peacock.remoteColor": "#c0f2c7"
+  "peacock.remoteColor": "#c0f2c7",
+  "cSpell.enabled": false
 }

--- a/docs/docs/segment-wifi.md
+++ b/docs/docs/segment-wifi.md
@@ -1,0 +1,47 @@
+---
+id: wifi
+title: WiFi
+sidebar_label: WiFi
+---
+
+## What
+
+Show details about the connected WiFi network.
+
+## Sample Configuration
+
+```json
+{
+  "type": "wifi",
+  "style": "powerline",
+  "background": "#8822ee",
+  "foreground": "#eeeeee",
+  "powerline_symbol": "\uE0B0",
+  "properties": {
+    "template": "{{if eq .State \"connected\"}}{{.SSID}} {{.Signal}}% {{.ReceiveRate}}Mbps{{else}}{{.State}}{{end}}"
+  }
+}
+```
+
+## Properties
+
+- connected_icon: `string` - the icon to use when WiFi is connected - defaults to `\uFAA8`
+- connected_icon: `string` - the icon to use when WiFi is disconnected - defaults to `\uFAA9`
+- template: `string` - A go [text/template][go-text-template] template extended with [sprig][sprig]
+utilizing the properties below - 
+defaults to `{{if .Connected}}{{.SSID}} {{.Signal}}% {{.ReceiveRate}}Mbps{{else}}{{.State}}{{end}}`
+
+## Template Properties
+
+- `.Connected`: `bool` - if WiFi is currently connected
+- `.State`: `string` - WiFi connection status - e.g. connected or disconnected
+- `.SSID`: `string` - the SSID of the current wifi network
+- `.RadioType`: `string` - the radio type - e.g. 802.11ac, 802.11ax, 802.11n, etc.
+- `.Authentication`: `string` - the authentication type - e.g. WPA2-Personal, WPA2-Enterprise, etc.
+- `.Channel`: `int` - the current channel number
+- `.ReceiveRate`: `int` - the receive rate (Mbps)
+- `.TransmitRate`: `int` - the transmit rate (Mbps)
+- `.Signal`: `int` - the signal strength (%)
+
+[go-text-template]: https://golang.org/pkg/text/template/
+[sprig]: https://masterminds.github.io/sprig/

--- a/docs/docs/segment-wifi.md
+++ b/docs/docs/segment-wifi.md
@@ -28,7 +28,7 @@ Show details about the connected WiFi network.
 - connected_icon: `string` - the icon to use when WiFi is connected - defaults to `\uFAA8`
 - connected_icon: `string` - the icon to use when WiFi is disconnected - defaults to `\uFAA9`
 - template: `string` - A go [text/template][go-text-template] template extended with [sprig][sprig]
-utilizing the properties below - 
+utilizing the properties below -
 defaults to `{{if .Connected}}{{.SSID}} {{.Signal}}% {{.ReceiveRate}}Mbps{{else}}{{.State}}{{end}}`
 
 ## Template Properties

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -71,6 +71,7 @@ module.exports = {
         "terraform",
         "text",
         "time",
+        "wifi",
         "ytm",
       ],
     },

--- a/src/segment.go
+++ b/src/segment.go
@@ -130,6 +130,8 @@ const (
 	Angular SegmentType = "angular"
 	// PHP writes which php version is currently active
 	PHP SegmentType = "php"
+	// WiFi writes details about the current WiFi connection
+	WiFi SegmentType = "wifi"
 )
 
 func (segment *Segment) string() string {
@@ -263,6 +265,7 @@ func (segment *Segment) mapSegmentWithWriter(env environmentInfo) error {
 		SysInfo:       &sysinfo{},
 		Angular:       &angular{},
 		PHP:           &php{},
+		WiFi:          &wifi{},
 	}
 	if writer, ok := functions[segment.Type]; ok {
 		props := &properties{

--- a/src/segment_wifi.go
+++ b/src/segment_wifi.go
@@ -116,38 +116,3 @@ func (w *wifi) init(props *properties, env environmentInfo) {
 	w.props = props
 	w.env = env
 }
-
-/* Disconnected
-`
-There is 1 interface on the system:
-
-    Name                   : Wi-Fi
-    Description            : Intel(R) Wireless-AC 9560 160MHz
-    GUID                   : 6bb8def2-9af2-4bd4-8be2-6bd54e46bdc9
-    Physical address       : d4:3b:04:e6:10:40
-    State                  : disconnected
-    Radio status           : Hardware On
-                             Software On
-
-    Hosted network status  : Not available
-
-`
-*/
-
-/* WiFi Off
-`
-
-There is 1 interface on the system:
-
-    Name                   : Wi-Fi
-    Description            : Intel(R) Wireless-AC 9560 160MHz
-    GUID                   : 6bb8def2-9af2-4bd4-8be2-6bd54e46bdc9
-    Physical address       : d4:3b:04:e6:10:40
-    State                  : disconnected
-    Radio status           : Hardware On
-                             Software Off
-
-    Hosted network status  : Not available
-
-`
-*/

--- a/src/segment_wifi.go
+++ b/src/segment_wifi.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+)
+
+type wifi struct {
+	props              *properties
+	env                environmentInfo
+	State              string
+	SSID               string
+	RadioType          string
+	AuthenticationType string
+	Channel            string
+	ReceiveRate        string
+	TransmitRate       string
+	SignalStrength     string
+}
+
+const (
+	State              = "State"
+	SSID               = "SSID"
+	RadioType          = "Radio type"
+	AuthenticationType = "Authentication"
+	Channel            = "Channel"
+	ReceiveRate        = "Receive rate (Mbps)"
+	TransmitRate       = "Transmit rate (Mbps)"
+	SignalStrength     = "Signal"
+)
+
+func (w *wifi) enabled() bool {
+	// If in Linux, who wnows. Gonna need a physical linux machine to develop this since the wlan interface isn't available in wsl
+	// But possible solution is to cat /proc/net/wireless, and if that file doesn't exist then don't show the segment
+	// In Windows and in wsl you can use the command `netsh.exe wlan show interfaces`. Note the .exe is important for this to worw in wsl.
+	if w.env.getPlatform() == windowsPlatform || w.env.isWsl() {
+		cmd := "netsh"
+		if !w.env.hasCommand(cmd) {
+			return false
+		}
+		cmdResult, err := w.env.runCommand(cmd, "wlan", "show", "interfaces")
+		displayError := w.props.getBool(DisplayError, false)
+		if err != nil && displayError {
+			w.State = "WIFI ERR"
+			// w.Namespace = w.Context
+			return true
+		}
+		if err != nil {
+			return false
+		}
+
+		regex := regexp.MustCompile(`(.+) : (.+)`)
+		lines := strings.Split(cmdResult, "\n")
+		for _, line := range lines[3 : len(lines)-3] {
+			matches := regex.FindStringSubmatch(line)
+			if len(matches) != 3 {
+				continue
+			}
+			name := strings.TrimSpace(matches[1])
+			value := strings.TrimSpace(matches[2])
+
+			switch name {
+			case State:
+				w.State = value
+			case SSID:
+				w.SSID = value
+			case RadioType:
+				w.RadioType = value
+			case AuthenticationType:
+				w.AuthenticationType = value
+			case Channel:
+				w.Channel = value
+			case ReceiveRate:
+				w.ReceiveRate = strings.Split(value, ".")[0]
+			case TransmitRate:
+				w.TransmitRate = strings.Split(value, ".")[0]
+			case SignalStrength:
+				w.SignalStrength = value
+			}
+		}
+	}
+
+	return true
+}
+
+func (w *wifi) string() string {
+	segmentTemplate := w.props.getString(SegmentTemplate, "{{.SSID}} {{.SignalStrength}} {{.ReceiveRate}}Mbps")
+	template := &textTemplate{
+		Template: segmentTemplate,
+		Context:  w,
+		Env:      w.env,
+	}
+	text, err := template.render()
+	if err != nil {
+		return err.Error()
+	}
+	return text
+}
+
+func (w *wifi) init(props *properties, env environmentInfo) {
+	w.props = props
+	w.env = env
+}

--- a/src/segment_wifi_test.go
+++ b/src/segment_wifi_test.go
@@ -89,7 +89,7 @@ func TestWifi_Enabled_ForWindows_WhenCommandNotFound_IsNotEnabled(t *testing.T) 
 
 func TestWifi_Enabled_ForWindows_WhenRunCommandFails_IsNotEnabled(t *testing.T) {
 	args := &wifiArgs{
-		commandError: errors.New("Oh noes!"),
+		commandError: errors.New("intentional testing failure"),
 		hasCommand:   true,
 	}
 	wifi := bootStrapEnvironment(args)
@@ -99,7 +99,7 @@ func TestWifi_Enabled_ForWindows_WhenRunCommandFails_IsNotEnabled(t *testing.T) 
 func TestWifi_Enabled_ForWindows_WhenRunCommandFailsWithDisplayError_IsEnabledWithErrorState(t *testing.T) {
 	args := &wifiArgs{
 		hasCommand:   true,
-		commandError: errors.New("Oh noes!"),
+		commandError: errors.New("intentional testing failure"),
 		displayError: true,
 	}
 	wifi := bootStrapEnvironment(args)

--- a/src/segment_wifi_test.go
+++ b/src/segment_wifi_test.go
@@ -1,54 +1,210 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
-const netshOutput string = `
-There is 1 interface on the system:
+type wifiArgs struct {
+	shell    string
+	platform string
+	isWsl    bool
 
-    Name                   : Wi-Fi
-    Description            : Intel(R) Wireless-AC 9560 160MHz
-    GUID                   : 6bb8def2-9af2-4bd4-8be2-6bd54e46bdc9
-    Physical address       : d4:3b:04:e6:10:40
-    State                  : connected
-    SSID                   : ohsiggy
-    BSSID                  : 5c:7d:7d:82:c5:73
-    Network type           : Infrastructure
-    Radio type             : 802.11ac
-    Authentication         : WPA2-Personal
-    Cipher                 : CCMP
-    Connection mode        : Profile
-    Channel                : 64
-    Receive rate (Mbps)    : 526.5
-    Transmit rate (Mbps)   : 780
-    Signal                 : 94%
-    Profile                : ohsiggy
+	command       string
+	commandOutput string
+	commandError  error
+	hasCommand    bool
 
-    Hosted network status  : Not available
+	displayError    bool
+	segmentTemplate string
+}
 
+type netshStringArgs struct {
+	state          string
+	ssid           string
+	radioType      string
+	authentication string
+	channel        int
+	receiveRate    int
+	transmitRate   int
+	signal         int
+}
 
-`
+func getNetshString(args *netshStringArgs) string {
+	const netshString string = `
+	There is 1 interface on the system:
 
-func bootStrapWifiTest() *wifi {
-	env := new(MockedEnvironment)
-	env.On("getPlatform", nil).Return(windowsPlatform)
-	env.On("isWsl", nil).Return(false)
-	env.On("runShellCommand", pwsh, "netsh.exe wlan show interfaces").Return(netshOutput)
-	env.On("getShellName", nil).Return(pwsh)
-	// env.On("hasCommand", "terraform").Return(args.hasTfCommand)
-	// env.On("hasFolder", ".terraform").Return(args.hasTfFolder)
-	// env.On("runCommand", "terraform", []string{"workspace", "show"}).Return(args.workspaceName, nil)
+	Name                   : Wi-Fi
+	Description            : Intel(R) Wireless-AC 9560 160MHz
+	GUID                   : 6bb8def2-9af2-4bd4-8be2-6bd54e46bdc9
+	Physical address       : d4:3b:04:e6:10:40
+	State                  : %s
+	SSID                   : %s
+	BSSID                  : 5c:7d:7d:82:c5:73
+	Network type           : Infrastructure
+	Radio type             : %s
+	Authentication         : %s
+	Cipher                 : CCMP
+	Connection mode        : Profile
+	Channel                : %d
+	Receive rate (Mbps)    : %d
+	Transmit rate (Mbps)   : %d
+	Signal                 : %d%%
+	Profile                : ohsiggy
+
+	Hosted network status  : Not available`
+
+	return fmt.Sprintf(netshString, args.state, args.ssid, args.radioType, args.authentication, args.channel, args.receiveRate, args.transmitRate, args.signal)
+}
+
+func bootStrapWifiWindowsPwshTest(args *wifiArgs) *wifi {
+	args.platform = windowsPlatform
+	args.shell = pwsh
+	args.command = "netsh"
+	args.isWsl = false
+
+	env, props := bootStrapEnvironment(args)
+
 	k := &wifi{
 		env:   env,
-		props: &properties{},
+		props: props,
 	}
+
 	return k
 }
 
-func TestString(t *testing.T) {
-	wifi := bootStrapWifiTest()
-	assert.NotNil(t, wifi.string())
+func bootStrapEnvironment(args *wifiArgs) (*MockedEnvironment, *properties) {
+	env := new(MockedEnvironment)
+	env.On("getPlatform", nil).Return(args.platform)
+	env.On("isWsl", nil).Return(args.isWsl)
+	env.On("hasCommand", args.command).Return(args.hasCommand)
+	env.On("runCommand", mock.Anything, mock.Anything).Return(args.commandOutput, args.commandError)
+	env.On("getShellName", nil).Return(args.shell)
+
+	props := &properties{
+		values: map[Property]interface{}{
+			DisplayError:    args.displayError,
+			SegmentTemplate: args.segmentTemplate,
+		},
+	}
+
+	return env, props
+}
+
+func TestWifi_Enabled_ForWindowsPwsh_WhenCommandNotFound_IsNotEnabled(t *testing.T) {
+	args := &wifiArgs{
+		hasCommand: false,
+	}
+	wifi := bootStrapWifiWindowsPwshTest(args)
+	assert.False(t, wifi.enabled())
+}
+
+func TestWifi_Enabled_ForWindowsPwsh_WhenRunCommandFails_IsNotEnabled(t *testing.T) {
+	args := &wifiArgs{
+		commandError: errors.New("Oh noes!"),
+		hasCommand:   true,
+	}
+	wifi := bootStrapWifiWindowsPwshTest(args)
+	assert.False(t, wifi.enabled())
+}
+
+func TestWifi_Enabled_ForWindowsPwsh_WhenRunCommandFailsWithDisplayError_IsEnabledWithErrorState(t *testing.T) {
+	args := &wifiArgs{
+		hasCommand:   true,
+		commandError: errors.New("Oh noes!"),
+		displayError: true,
+	}
+	wifi := bootStrapWifiWindowsPwshTest(args)
+	assert.True(t, wifi.enabled())
+	assert.Equal(t, "WIFI ERR", wifi.State)
+}
+
+func TestWifi_Enabled_ForWindowsPwsh_HappyPath_IsEnabled(t *testing.T) {
+	args := &wifiArgs{
+		hasCommand:    true,
+		commandOutput: "",
+	}
+	wifi := bootStrapWifiWindowsPwshTest(args)
+	assert.True(t, wifi.enabled())
+}
+
+func TestWifi_Enabled_ForWindowsPwsh_HappyPath(t *testing.T) {
+	expected := &netshStringArgs{
+		state:          "connected",
+		ssid:           "ohsiggy",
+		radioType:      "802.11ac",
+		authentication: "WPA2-Personal",
+		channel:        99,
+		receiveRate:    500.0,
+		transmitRate:   400.0,
+		signal:         80,
+	}
+
+	args := &wifiArgs{
+		hasCommand:    true,
+		commandOutput: getNetshString(expected),
+	}
+	wifi := bootStrapWifiWindowsPwshTest(args)
+	enabled := wifi.enabled()
+	assert.True(t, enabled)
+	assert.Equal(t, expected.state, wifi.State)
+	assert.Equal(t, expected.ssid, wifi.SSID)
+	assert.Equal(t, expected.radioType, wifi.RadioType)
+	assert.Equal(t, expected.authentication, wifi.Authentication)
+	assert.Equal(t, expected.channel, wifi.Channel)
+	assert.Equal(t, expected.receiveRate, wifi.ReceiveRate)
+	assert.Equal(t, expected.transmitRate, wifi.TransmitRate)
+	assert.Equal(t, expected.signal, wifi.Signal)
+}
+
+func TestWifi_String_ForWindowsPwsh_HappyPath(t *testing.T) {
+	expected := &netshStringArgs{
+		state:          "connected",
+		ssid:           "ohsiggy",
+		radioType:      "802.11ac",
+		authentication: "WPA2-Personal",
+		channel:        99,
+		receiveRate:    500.0,
+		transmitRate:   400.0,
+		signal:         80,
+	}
+
+	args := &wifiArgs{
+		hasCommand:      true,
+		commandOutput:   getNetshString(expected),
+		segmentTemplate: "{{.State}}{{.SSID}}{{.RadioType}}{{.Authentication}}{{.Channel}}{{.ReceiveRate}}{{.TransmitRate}}{{.Signal}}",
+	}
+	wifi := bootStrapWifiWindowsPwshTest(args)
+	assert.True(t, wifi.enabled())
+
+	expectedString := fmt.Sprintf("%s%s%s%s%d%d%d%d",
+		wifi.State, wifi.SSID, wifi.RadioType, wifi.Authentication, wifi.Channel, wifi.ReceiveRate, wifi.TransmitRate, wifi.Signal)
+	assert.Equal(t, expectedString, wifi.string())
+}
+
+func TestWifi_String_ForWindowsPwsh_TemplateRenderError_ReturnsError(t *testing.T) {
+	expected := &netshStringArgs{
+		state:          "connected",
+		ssid:           "ohsiggy",
+		radioType:      "802.11ac",
+		authentication: "WPA2-Personal",
+		channel:        99,
+		receiveRate:    500.0,
+		transmitRate:   400.0,
+		signal:         80,
+	}
+
+	args := &wifiArgs{
+		hasCommand:      true,
+		commandOutput:   getNetshString(expected),
+		segmentTemplate: "{{.DoesNotExist}}",
+	}
+	wifi := bootStrapWifiWindowsPwshTest(args)
+	assert.True(t, wifi.enabled())
+
+	assert.Equal(t, "unable to create text based on template", wifi.string())
 }

--- a/src/segment_wifi_test.go
+++ b/src/segment_wifi_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const netshOutput string = `
+There is 1 interface on the system:
+
+    Name                   : Wi-Fi
+    Description            : Intel(R) Wireless-AC 9560 160MHz
+    GUID                   : 6bb8def2-9af2-4bd4-8be2-6bd54e46bdc9
+    Physical address       : d4:3b:04:e6:10:40
+    State                  : connected
+    SSID                   : ohsiggy
+    BSSID                  : 5c:7d:7d:82:c5:73
+    Network type           : Infrastructure
+    Radio type             : 802.11ac
+    Authentication         : WPA2-Personal
+    Cipher                 : CCMP
+    Connection mode        : Profile
+    Channel                : 64
+    Receive rate (Mbps)    : 526.5
+    Transmit rate (Mbps)   : 780
+    Signal                 : 94%
+    Profile                : ohsiggy
+
+    Hosted network status  : Not available
+
+
+`
+
+func bootStrapWifiTest() *wifi {
+	env := new(MockedEnvironment)
+	env.On("getPlatform", nil).Return(windowsPlatform)
+	env.On("isWsl", nil).Return(false)
+	env.On("runShellCommand", pwsh, "netsh.exe wlan show interfaces").Return(netshOutput)
+	env.On("getShellName", nil).Return(pwsh)
+	// env.On("hasCommand", "terraform").Return(args.hasTfCommand)
+	// env.On("hasFolder", ".terraform").Return(args.hasTfFolder)
+	// env.On("runCommand", "terraform", []string{"workspace", "show"}).Return(args.workspaceName, nil)
+	k := &wifi{
+		env:   env,
+		props: &properties{},
+	}
+	return k
+}
+
+func TestString(t *testing.T) {
+	wifi := bootStrapWifiTest()
+	assert.NotNil(t, wifi.string())
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -168,7 +168,8 @@
             "owm",
             "sysinfo",
             "angular",
-            "php"
+            "php",
+            "wifi"
           ]
         },
         "style": {
@@ -1680,6 +1681,38 @@
                   },
                   "display_mode": {
                     "$ref": "#/definitions/display_mode"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": { "const": "wifi" }
+            }
+          },
+          "then": {
+            "title": "WiFi Segment",
+            "description": "https://ohmyposh.dev/docs/wifi",
+            "properties": {
+              "properties": {
+                "properties": {
+                  "connected_icon": {
+                    "type": "string",
+                    "title": "Connected Icon",
+                    "description": "The icon to use when WiFi is connected",
+                    "default": "\uFAA8"
+                  },
+                  "disconnected_icon": {
+                    "type": "string",
+                    "title": "Disconnected Icon",
+                    "description": "The icon to use when WiFi is disconnected",
+                    "default": "\uFAA9"
+                  },
+                  "template": {
+                    "$ref": "#/definitions/template"
                   }
                 }
               }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

This is a WiFi segment to display details of the current WiFi connection. I've only tested it so far on Windows, but the `netsh` command that makes it work there, also works in WSL. So I am pretty sure it will work in WSL too, but obviously need to test.

Any suggestions for how to do that? I was thinking I'd just re-clone the repo in WSL and install another Go environment there, build it, and test.

Also, for the Linux functionality, I tried to use the Dev Container in this project, but after much Googling it turns out virtual environments like that don't actually have a WiFi network interface. The data should be in `/proc/net/wireless`, but as I don't have a physical Linux machine to test with, I cannot develop this functionality. So I'm hoping it's cool to submit this with just Windows and WSL for now. And perhaps a kind contributor could help with the Linux and Darwin code!

Please let me know what you think of the PR. I am very happy to make any changes you request.

Here's a sample of what it looks like with the default template:

![image](https://user-images.githubusercontent.com/811177/142752960-9b45254f-1b76-4f2b-afc8-b409d3f75c8d.png)


[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
